### PR TITLE
FIX: Issue on iPhone 11 not show backdrop full size

### DIFF
--- a/components/MultiDrawer.vue
+++ b/components/MultiDrawer.vue
@@ -7,7 +7,6 @@
                ref="backDrop"
                iosOverflowSafeArea="true"
                opacity="0"
-               iosOverflowSafeArea="true"
                :backgroundColor="optionsInternal.backdropColor"
                @pan="onBackDropPan"
                @tap="close()"/>

--- a/components/MultiDrawer.vue
+++ b/components/MultiDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-    <GridLayout>
+    <GridLayout iosOverflowSafeArea="true">
         <!-- Main Content (default slot) -->
         <slot/>
 
@@ -7,6 +7,7 @@
                ref="backDrop"
                iosOverflowSafeArea="true"
                opacity="0"
+               iosOverflowSafeArea="true"
                :backgroundColor="optionsInternal.backdropColor"
                @pan="onBackDropPan"
                @tap="close()"/>


### PR DESCRIPTION
Hello @rigor789 can you please accept my pull request, i found an issue on iPhone 11 backdrop isn't full size, you can see here:

IPHONE 11 (BUG)
![Screenshot 2020-06-21 at 14 10 58](https://user-images.githubusercontent.com/1126525/85226043-3bbb0000-b3cd-11ea-97d2-fb3d335773ae.png)

IPHONE 8 (GOOD)
![Screenshot 2020-06-21 at 14 40 53](https://user-images.githubusercontent.com/1126525/85226093-994f4c80-b3cd-11ea-892b-650c29a4fccf.png)


Please accept my pull request as soon as possible, because for me it's importante to be resolve. :( 

After the fix, i can now see correct backdrop:
![Screenshot 2020-06-21 at 14 42 19](https://user-images.githubusercontent.com/1126525/85226081-7755ca00-b3cd-11ea-991c-5a7541d82bcb.png)

